### PR TITLE
Add error handler for frequency setting on FSW00x0

### DIFF
--- a/ogameasure/device/Phasematrix/QuickSyn_FSW0000.py
+++ b/ogameasure/device/Phasematrix/QuickSyn_FSW0000.py
@@ -274,5 +274,5 @@ class FSW0010(FSW0000):
 class FSW0020(FSW0000):
     product_name = 'FSW-0020'
     freq_range_ghz = (0.5, 20)
-    power_default_dbm = 15
+    power_default_dbm = 13
     power_range_dbm = (-10, 13)

--- a/ogameasure/device/Phasematrix/QuickSyn_FSW0000.py
+++ b/ogameasure/device/Phasematrix/QuickSyn_FSW0000.py
@@ -267,7 +267,7 @@ class FSW0000(scpi.scpi_family):
 
 class FSW0010(FSW0000):
     product_name = 'FSW-0010'
-    freq_range_ghz = (0.5, 20)
+    freq_range_ghz = (0.5, 10)
     power_default_dbm = 15
     power_range_dbm = (-25, 15)
 

--- a/ogameasure/device/Phasematrix/QuickSyn_FSW0000.py
+++ b/ogameasure/device/Phasematrix/QuickSyn_FSW0000.py
@@ -43,7 +43,7 @@ class FSW0000(scpi.scpi_family):
         >>> s.freq_set(1.234, 'MHz')
         >>> s.freq_set(98765.4321, 'kHz')
         """
-        self.com.send('FREQ {0:10f}{1}\n'.format(freq, unit))
+        self.com.send('FREQ {0}{1}\n'.format(freq, unit))
         time.sleep(delay_time)
         try:
             ret = self.com.recv()

--- a/ogameasure/device/Phasematrix/QuickSyn_FSW0000.py
+++ b/ogameasure/device/Phasematrix/QuickSyn_FSW0000.py
@@ -1,4 +1,5 @@
 import time
+from socket import timeout
 from ..SCPI import scpi
 
 # main class
@@ -44,10 +45,12 @@ class FSW0000(scpi.scpi_family):
         """
         self.com.send('FREQ {0:10f}{1}\n'.format(freq, unit))
         time.sleep(delay_time)
-        ret = self.com.recv()
-        if b"Data out of range" in ret:
-            raise ValueError(ret)
-        return
+        try:
+            ret = self.com.recv()
+            if b"Data out of range" in ret:
+                raise ValueError(ret)
+        except timeout:
+            pass
 
     def freq_query(self):
         """

--- a/ogameasure/device/Phasematrix/QuickSyn_FSW0000.py
+++ b/ogameasure/device/Phasematrix/QuickSyn_FSW0000.py
@@ -59,7 +59,7 @@ class FSW0000(scpi.scpi_family):
         else:
             raise ValueError(f"Invalid unit: {unit}")
 
-        if not (self.freq_ghz[0] <= freq_ghz <= self.freq_ghz[1]):
+        if not (self.freq_range_ghz[0] <= freq_ghz <= self.freq_range_ghz[1]):
             raise ValueError(
                 "Frequency must be "
                 f"between {self.freq_range_ghz[0]} and {self.freq_range_ghz[1]} GHz."

--- a/ogameasure/device/Phasematrix/QuickSyn_FSW0000.py
+++ b/ogameasure/device/Phasematrix/QuickSyn_FSW0000.py
@@ -14,8 +14,8 @@ class FSW0000(scpi.scpi_family):
     _scpi_enable = '*IDN? *RCL *RST'
 
     freq_range_ghz = ()
-    power_default_dbm = 0
-    power_range_dbm = ()
+    power_default_dbm = 0  # Currently not used.
+    power_range_dbm = ()  # Currently not used.
 
     def _error_check(self):
         return

--- a/ogameasure/device/Phasematrix/QuickSyn_FSW0000.py
+++ b/ogameasure/device/Phasematrix/QuickSyn_FSW0000.py
@@ -28,12 +28,12 @@ class FSW0000(scpi.scpi_family):
         < freq : float :  >
             A frequency value.
 
-        < unit : str : 'GHz','MHz','kHz','Hz' >
+        < unit : str : 'GHz','MHz','kHz','mlHz' >
             Specify the units of the <freq>.
-            'GHz', 'MHz', 'kHz' or 'Hz'. default = 'GHz'
+            'GHz', 'MHz', 'kHz' or 'mlHz'. default = 'GHz'
 
-        Returnes
-        ========
+        Returns
+        =======
         Nothing.
 
         Examples
@@ -43,6 +43,10 @@ class FSW0000(scpi.scpi_family):
         >>> s.freq_set(98765.4321, 'kHz')
         """
         self.com.send('FREQ {0:10f}{1}\n'.format(freq, unit))
+        time.sleep(delay_time)
+        ret = self.com.recv()
+        if b"Data out of range" in ret:
+            raise ValueError(ret)
         return
 
     def freq_query(self):
@@ -56,14 +60,14 @@ class FSW0000(scpi.scpi_family):
         ====
         Nothing.
 
-        Returnes
+        Returns
         ========
         < freq : float :  >
             A frequency value in Hz.
 
         Examples
         ========
-        >>> s.freq_get()
+        >>> s.freq_query()
         +2.0000000e+10
         """
         self.com.send('FREQ?\n')
@@ -88,8 +92,8 @@ class FSW0000(scpi.scpi_family):
             Specify the units of the <pow>.
             'dBm'. default = 'dBm'
 
-        Returnes
-        ========
+        Returns
+        =======
         Nothing.
 
         Examples
@@ -110,14 +114,14 @@ class FSW0000(scpi.scpi_family):
         ====
         Nothing.
 
-        Returnes
-        ========
+        Returns
+        =======
         < power : float :  >
             A power value in dBm.
 
         Examples
         ========
-        >>> s.freq_get()
+        >>> s.power_query()
         10.1
         """
         self.com.send('POW?\n')
@@ -139,8 +143,8 @@ class FSW0000(scpi.scpi_family):
         < output : str,int : 'ON','OFF',1,0 >
             Enable/disable the RF output.
 
-        Returnes
-        ========
+        Returns
+        =======
         Nothing.
 
         Examples
@@ -163,8 +167,8 @@ class FSW0000(scpi.scpi_family):
         ====
         Nothing.
 
-        Returnes
-        ========
+        Returns
+        =======
         Nothing.
 
         Examples
@@ -184,8 +188,8 @@ class FSW0000(scpi.scpi_family):
         ====
         Nothing.
 
-        Returnes
-        ========
+        Returns
+        =======
         Nothing.
 
         Examples
@@ -205,8 +209,8 @@ class FSW0000(scpi.scpi_family):
         ====
         Nothing.
 
-        Returnes
-        ========
+        Returns
+        =======
         < output : int : 1,0 >
             Enable/disable the RF output.
             1 = ON, 0 = OFF

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ long_description = (Path(__file__).parent / "README.md").read_text()
 
 setuptools.setup(
     name = 'ogameasure',
-    version = "0.5.3",
+    version = "0.5.4",
     description = 'Driver for SCPI device',
     long_description = long_description,
     long_description_content_type = "text/markdown",


### PR DESCRIPTION
This PR closes #14.

- 周波数の単位がいくつか指定できる実装なので、値を事前にチェックするのではなくエラーメッセージを確認するようにしています。
- 以下の行は周波数設定の有効桁数が一定しない実装になっています。修正の必要があればコメントください。
  https://github.com/ogawa-ros/ogameasure/blob/98c4d7fe954e19e78ae77fb8bb5efdf66cfa8e57/ogameasure/device/Phasematrix/QuickSyn_FSW0000.py#L45
  - 例)
    ```python
    >>> 'FREQ {0:10f}{1}\n'.format(1.23456789, "GHz")
    'FREQ   1.234568GHz\n'
    ```