### PR TITLE
Keep a persistent PTP session for Canon M100 instead of reopening per shot

### DIFF
--- a/ogameasure/device/Canon/M100_raspi.py
+++ b/ogameasure/device/Canon/M100_raspi.py
@@ -1,73 +1,85 @@
-from __future__ import print_function
 import logging
-import os
-import subprocess
-import sys
-import gphoto2 as gp
 import time
-import socket
+from pathlib import Path
 
-# time1 = time.ctime()
-# time2 = time.strptime(time1)
-# time3 = time.strftime('%Y%m%d_%H.%M.%S', time2)
-timestr = time.strftime("%Y%m%d_%H.%M.%S", time.strptime(time.ctime()))
-
-# savedir_pre = '/home/1.85m/evaluation/optical_pointing/test/fig/'
-
-HOST = "192.168.100.12"
-PORT = 50000
-
-# def capture(savedir, imagename):
-# f = open('%s%s'%(savedir, imagename), 'w')
-# f.write('test')
-# f.close()
+import gphoto2 as gp
 
 
-class m100(object):
-    def capture(self, savepath):
-        # savedir = './picture/'+timestr+'.JPG'
-        savedir = savepath
+class m100:
+    def __init__(self):
         logging.basicConfig(
-            format="%(levelname)s: %(name)s: %(massage)s", level=logging.WARNING
+            format="%(levelname)s: %(name)s: %(message)s",
+            level=logging.WARNING,
         )
         gp.check_result(gp.use_python_logging())
-        camera = gp.check_result(gp.gp_camera_new())
-        gp.check_result(gp.gp_camera_init(camera))
+
+        self.camera = gp.check_result(gp.gp_camera_new())
+        gp.check_result(gp.gp_camera_init(self.camera))
+
+        print("Canon M100 connected")
+
+    def capture(self, savepath):
+        savepath = Path(savepath).expanduser()
+        savepath.parent.mkdir(parents=True, exist_ok=True)
+
         print("Capturing image")
-        file_path = gp.check_result(gp.gp_camera_capture(camera, gp.GP_CAPTURE_IMAGE))
-        # print('Camera file path: {0}/{1}'.format(file_path.folder, file_path.name))
-        # target = os.path.join(savedir, imagename)
-        # print('Copying image to', target)
-        camera_file = gp.check_result(
-            gp.gp_camera_file_get(
-                camera, file_path.folder, file_path.name, gp.GP_FILE_TYPE_NORMAL
+
+        file_path = gp.check_result(
+            gp.gp_camera_capture(
+                self.camera,
+                gp.GP_CAPTURE_IMAGE,
             )
         )
-        # gp.check_result(gp.gp_file_save(camera_file, target))
-        # timestr = time.strftime('%Y%m%d_%H.%M.%S', time.strptime(time.ctime()))
-        gp.check_result(gp.gp_file_save(camera_file, savedir))
-        # gp.check_result(gp.gp_file_save(camera_file, './picture/'+timestr+'.jpg'))
-        # subprocess.call(['xdg-open', target])
-        gp.check_result(gp.gp_camera_exit(camera))
+
+        camera_file = gp.check_result(
+            gp.gp_camera_file_get(
+                self.camera,
+                file_path.folder,
+                file_path.name,
+                gp.GP_FILE_TYPE_NORMAL,
+            )
+        )
+
+        gp.check_result(gp.gp_file_save(camera_file, str(savepath)))
+
+        # Drain the camera's post-capture events (e.g. file-added
+        # notifications) so they don't linger and interfere with the next
+        # capture on this same session.
+        for _ in range(30):
+            event_type, _ = gp.check_result(
+                gp.gp_camera_wait_for_event(
+                    self.camera,
+                    100,
+                )
+            )
+            if event_type == gp.GP_EVENT_TIMEOUT:
+                break
+
+        print(f"Saved: {savepath}")
         return "Shooting completed"
-        # return 0
 
+    def keepalive(self):
+        # Waits for camera events for only 100 ms; a lightweight way to poll
+        # the existing session without tearing it down. Do not call this
+        # concurrently with capture().
+        gp.check_result(
+            gp.gp_camera_wait_for_event(
+                self.camera,
+                100,
+            )
+        )
 
-"""
-s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-s.bind((HOST, PORT))
-s.listen(1)
-print('Server is listening for connections')
+    def close(self):
+        for _ in range(10):
+            result = gp.gp_camera_exit(self.camera)
 
-While True:
-    conn, addr = s.accept()
-    print('connected')
-    capture()
-    bytes = open('./picture/'+timestr+'.JPG', encoding='utf8', errors='ignore').read()
-    print(len(bytes), 'bytes')
-    bytes += '¥n'
-    _file = open('./picture/'+timestr+'.JPG', 'wb')
-    _file.write(bytes)
-    _file.close()
-    conn.send(bytes)
-"""
+            if result >= gp.GP_OK:
+                print("Canon M100 disconnected")
+                return
+
+            if result != gp.GP_ERROR_CAMERA_BUSY:
+                gp.check_result(result)
+
+            time.sleep(0.5)
+
+        logging.warning("Camera remained busy during shutdown")

--- a/ogameasure/device/Canon/M100_raspi.py
+++ b/ogameasure/device/Canon/M100_raspi.py
@@ -58,17 +58,6 @@ class m100:
         print(f"Saved: {savepath}")
         return "Shooting completed"
 
-    def keepalive(self):
-        # Waits for camera events for only 100 ms; a lightweight way to poll
-        # the existing session without tearing it down. Do not call this
-        # concurrently with capture().
-        gp.check_result(
-            gp.gp_camera_wait_for_event(
-                self.camera,
-                100,
-            )
-        )
-
     def close(self):
         for _ in range(10):
             result = gp.gp_camera_exit(self.camera)

--- a/ogameasure/device/Canon/M100_raspi.py
+++ b/ogameasure/device/Canon/M100_raspi.py
@@ -1,4 +1,5 @@
 import logging
+import threading
 import time
 from pathlib import Path
 
@@ -15,60 +16,72 @@ class m100:
 
         self.camera = gp.check_result(gp.gp_camera_new())
         gp.check_result(gp.gp_camera_init(self.camera))
+        self._lock = threading.RLock()
+        self._closed = False
 
         print("Canon M100 connected")
 
     def capture(self, savepath):
-        savepath = Path(savepath).expanduser()
-        savepath.parent.mkdir(parents=True, exist_ok=True)
+        with self._lock:
+            if self._closed:
+                raise RuntimeError("Canon M100 camera session is closed")
 
-        print("Capturing image")
+            savepath = Path(savepath).expanduser()
+            savepath.parent.mkdir(parents=True, exist_ok=True)
 
-        file_path = gp.check_result(
-            gp.gp_camera_capture(
-                self.camera,
-                gp.GP_CAPTURE_IMAGE,
-            )
-        )
+            print("Capturing image")
 
-        camera_file = gp.check_result(
-            gp.gp_camera_file_get(
-                self.camera,
-                file_path.folder,
-                file_path.name,
-                gp.GP_FILE_TYPE_NORMAL,
-            )
-        )
-
-        gp.check_result(gp.gp_file_save(camera_file, str(savepath)))
-
-        # Drain the camera's post-capture events (e.g. file-added
-        # notifications) so they don't linger and interfere with the next
-        # capture on this same session.
-        for _ in range(30):
-            event_type, _ = gp.check_result(
-                gp.gp_camera_wait_for_event(
+            file_path = gp.check_result(
+                gp.gp_camera_capture(
                     self.camera,
-                    100,
+                    gp.GP_CAPTURE_IMAGE,
                 )
             )
-            if event_type == gp.GP_EVENT_TIMEOUT:
-                break
 
-        print(f"Saved: {savepath}")
-        return "Shooting completed"
+            camera_file = gp.check_result(
+                gp.gp_camera_file_get(
+                    self.camera,
+                    file_path.folder,
+                    file_path.name,
+                    gp.GP_FILE_TYPE_NORMAL,
+                )
+            )
+
+            gp.check_result(gp.gp_file_save(camera_file, str(savepath)))
+
+            # Drain the camera's post-capture events (e.g. file-added
+            # notifications) so they don't linger and interfere with the next
+            # capture on this same session.
+            for _ in range(30):
+                event_type, _ = gp.check_result(
+                    gp.gp_camera_wait_for_event(
+                        self.camera,
+                        100,
+                    )
+                )
+                if event_type == gp.GP_EVENT_TIMEOUT:
+                    break
+
+            print(f"Saved: {savepath}")
+            return "Shooting completed"
 
     def close(self):
-        for _ in range(10):
-            result = gp.gp_camera_exit(self.camera)
-
-            if result >= gp.GP_OK:
-                print("Canon M100 disconnected")
+        with self._lock:
+            if self._closed:
                 return
 
-            if result != gp.GP_ERROR_CAMERA_BUSY:
-                gp.check_result(result)
+            for _ in range(10):
+                result = gp.gp_camera_exit(self.camera)
 
-            time.sleep(0.5)
+                if result >= gp.GP_OK:
+                    self._closed = True
+                    print("Canon M100 disconnected")
+                    return
 
-        logging.warning("Camera remained busy during shutdown")
+                if result != gp.GP_ERROR_CAMERA_BUSY:
+                    gp.check_result(result)
+
+                time.sleep(0.5)
+
+            message = "Canon M100 camera remained busy during shutdown"
+            raise RuntimeError(message)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ogameasure"
-version = "0.6.3"
+version = "0.6.4"
 description = "Driver for SCPI device"
 authors = [
     "Shota Ueda <s7u27astr0@gmail.com>",

--- a/tests/test_m100.py
+++ b/tests/test_m100.py
@@ -1,0 +1,111 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+MODULE_PATH = Path(__file__).parents[1]
+MODULE_PATH /= "ogameasure/device/Canon/M100_raspi.py"
+
+
+class FakeGPhoto2:
+    GP_OK = 0
+    GP_ERROR_CAMERA_BUSY = -110
+    GP_CAPTURE_IMAGE = 1
+    GP_FILE_TYPE_NORMAL = 2
+    GP_EVENT_TIMEOUT = 3
+
+    def __init__(self, exit_results=None):
+        self.camera = object()
+        self.exit_results = iter(exit_results or [self.GP_OK])
+        self.exit_calls = 0
+        self.capture_calls = 0
+
+    @staticmethod
+    def check_result(result):
+        if isinstance(result, int) and result < 0:
+            raise RuntimeError(f"gphoto2 error: {result}")
+        return result
+
+    @staticmethod
+    def use_python_logging():
+        return 0
+
+    def gp_camera_new(self):
+        return self.camera
+
+    @staticmethod
+    def gp_camera_init(camera):
+        return 0
+
+    def gp_camera_capture(self, camera, capture_type):
+        self.capture_calls += 1
+        return SimpleNamespace(folder="/store", name="image.jpg")
+
+    @staticmethod
+    def gp_camera_file_get(camera, folder, name, file_type):
+        return object()
+
+    @staticmethod
+    def gp_file_save(camera_file, savepath):
+        return 0
+
+    def gp_camera_wait_for_event(self, camera, timeout_ms):
+        return self.GP_EVENT_TIMEOUT, None
+
+    def gp_camera_exit(self, camera):
+        self.exit_calls += 1
+        return next(self.exit_results)
+
+
+def load_m100(monkeypatch, fake_gp):
+    monkeypatch.setitem(sys.modules, "gphoto2", fake_gp)
+    module_name = "m100_under_test"
+    spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    monkeypatch.setattr(module.time, "sleep", lambda _: None)
+    return module.m100
+
+
+def test_close_is_idempotent(monkeypatch):
+    fake_gp = FakeGPhoto2()
+    camera = load_m100(monkeypatch, fake_gp)()
+
+    camera.close()
+    camera.close()
+
+    assert fake_gp.exit_calls == 1
+
+
+def test_capture_after_close_fails_without_using_camera(monkeypatch, tmp_path):
+    fake_gp = FakeGPhoto2()
+    camera = load_m100(monkeypatch, fake_gp)()
+    camera.close()
+
+    with pytest.raises(RuntimeError, match="session is closed"):
+        camera.capture(tmp_path / "image.jpg")
+
+    assert fake_gp.capture_calls == 0
+
+
+def test_close_retries_busy_then_succeeds(monkeypatch):
+    busy_then_ok = [FakeGPhoto2.GP_ERROR_CAMERA_BUSY, FakeGPhoto2.GP_OK]
+    fake_gp = FakeGPhoto2(busy_then_ok)
+    camera = load_m100(monkeypatch, fake_gp)()
+
+    camera.close()
+
+    assert fake_gp.exit_calls == 2
+
+
+def test_close_raises_when_camera_stays_busy(monkeypatch):
+    fake_gp = FakeGPhoto2([FakeGPhoto2.GP_ERROR_CAMERA_BUSY] * 10)
+    camera = load_m100(monkeypatch, fake_gp)()
+
+    with pytest.raises(RuntimeError, match="remained busy"):
+        camera.close()
+
+    assert fake_gp.exit_calls == 10
+    assert camera._closed is False


### PR DESCRIPTION
Closes #95

## 問題

`m100.capture()` は撮影のたびに `gp_camera_new/init/exit` でUSB/PTPセッションを完全に張り直していた。NECST側はカメラオブジェクトを起動時に1回生成し、以降同じインスタンスの `capture()` を繰り返し呼ぶ構造のため、撮影の合間はセッションが完全に切れている。

外部で `gphoto2 --wait-event` 等を常駐させてカメラを起こしておく回避策も、USB/PTP接続は1プロセスが占有するため撮影時に "Could not claim the USB device" を招きうり、採用できない。

## 修正

- `__init__()` でカメラ接続を確立し、以降の `capture()` 呼び出し間で保持する
- `close()` を新設し、終了時のみ `gp_camera_exit()` する（`GP_ERROR_CAMERA_BUSY` はリトライ）
- 撮影後にカメラ内部イベントをドレインし、次の撮影に影響しないようにする

## 注記(2026-07-30): keepalive()は削除済み

当初、既存セッションを維持したまま軽くポーリングする `keepalive()` を追加していたが、実機(M100 raspi)で30秒おきに呼び続けたところ、起動後20〜30分でセグフォルトが発生する事象を確認した。USB接続自体は切断されておらず(dmesg確認済み)、`gp_camera_wait_for_event`の反復呼び出し自体が原因と考えられる。呼び出し側(necst-telescope/necst#481, necst-telescope/neclib#792)も対応する呼び出しを削除済みで、根本原因の特定には至らなかったため、本PRからも`keepalive()`を削除した。

## 影響

呼び出し側（necst-telescope/neclib の `M100` ドライバ）の `finalize()` は現在 `self.ccd.com.close()`（存在しない属性）を呼んでいるため、`close()` を呼ぶよう別PRで追随修正する。

## テスト計画

- [x] 実機（M100 + Raspberry Pi）で、CCDノードを起動したまま複数回連続撮影できることを確認
- [x] 10〜20分程度放置後（カメラのオートパワーオフを跨ぐ）でも撮影できるか確認 → 20〜30分でsegfault確認(keepalive由来と判断し削除)
- [ ] ノード終了時に `close()` が正常にセッションを解放することを確認